### PR TITLE
Ft/ym 렌더링, 로그인 관련 문제들 수정

### DIFF
--- a/src/components/bookmark/BookmarkList.tsx
+++ b/src/components/bookmark/BookmarkList.tsx
@@ -1,60 +1,44 @@
 import React, { useContext, useEffect, useState } from 'react'
 import { HFlex } from '../../custom/ym/styleStore'
-import { FILTER_LIST } from '../../custom/ym/variables'
 import { Categories } from '../ui/element/tags/Categories'
 import uuid from 'react-uuid'
-import { FolderData, ReceivedBookmarks, ScrapListEachData, categoryTypes } from '../../custom/ym/types'
+import { FolderData } from '../../custom/ym/types'
 import BookmarkLoginComp from './BookmarkLoginComp'
 import BookmarkLogoutComp from './BookmarkLogoutComp'
-import { bookmarkData } from '../../custom/ym/dummydata'
-import { useQuery } from '@tanstack/react-query'
-import { api_token } from '../../shared/api'
-import { apiPath } from '../../shared/path'
-import { scrapKeys } from '../../apis/queries'
-import { queryClient } from '../..'
-import useScrapData from '../../hooks/useScrapData'
 import { ScrapContext } from '../../pages/Bookmark'
 
 const BookmarkList = () => {
 
     const [folder, setFolder] = useState<FolderData | null>();
     const [folderList, setFolderList] = useState<FolderData[]>([]);
-    // const [scrapList, setScrapList] = useState<ScrapListEachData[]>([]);
     const [isLogin, setIsLogin] = useState<boolean>(false);
 
     const { queryData } = useContext(ScrapContext);
-    const { scrapData, refetchScrapQuery, isSuccess, isError } = useScrapData();
 
-    const folderClickHandler = (
-        e: React.MouseEvent<HTMLButtonElement>,
-        element: FolderData
-    ) => {
-        if (isLogin) {
-            element.folderName === folder?.folderName
-                ? setFolder(null)
-                : setFolder(element)
-        }
+    const folderClickHandler = (element: FolderData) => {
+        isLogin && element.folderName === folder?.folderName
+            ? setFolder(null)
+            : setFolder(element)
     }
 
     useEffect(() => {
-        const data = scrapData as ReceivedBookmarks;
-        console.log('폴더리스트:', data);
-        setFolder(data?.folderList[0]);
-        localStorage.getItem("access_token") && setIsLogin(prev => !prev);
-        data?.folderList && setFolderList(data?.folderList);
-    }, [])
+        localStorage.getItem("access_token") && setIsLogin(true);
+        setFolderList(queryData?.folderList as FolderData[]);
+        setFolder(queryData?.folderList[0]);
+    }, [queryData]);
+
 
     return (
         <>
             <HFlex gap='2px' height='fit-content' etc="padding:8px 20px;">
                 {
-                    folderList.length > 0 && folderList.map((element) => {
+                    folderList?.map((element) => {
                         if (folder === element) {
                             return (
                                 <Categories.Active
                                     key={uuid()}
                                     name={element.folderName}
-                                    onClick={(e) => folderClickHandler(e, element)}
+                                    onClick={() => folderClickHandler(element)}
                                 >{element.folderName}</Categories.Active>
                             );
                         } else {
@@ -62,7 +46,7 @@ const BookmarkList = () => {
                                 <Categories.Inactive
                                     key={uuid()}
                                     name={element.folderName}
-                                    onClick={(e) => folderClickHandler(e, element)}
+                                    onClick={() => folderClickHandler(element)}
                                 >{element.folderName}</Categories.Inactive>
                             )
                         }

--- a/src/components/bookmark/BookmarkLoginComp.tsx
+++ b/src/components/bookmark/BookmarkLoginComp.tsx
@@ -12,7 +12,7 @@ import { ScrapContext } from '../../pages/Bookmark';
 const BookmarkLoginComp = ({ folderState }: FolderProp) => {
 
     const navi = useNavigate();
-    const { scrapList } = useContext(ScrapContext);
+    const { scrapList, queryData } = useContext(ScrapContext);
 
     const [folderList, setFolderList] = useState<FolderData[]>();
 
@@ -29,7 +29,7 @@ const BookmarkLoginComp = ({ folderState }: FolderProp) => {
         };
         const folders = copy?.folderList;
         setFolderList(prev => folders);
-    }, []);
+    }, [scrapList]);
 
 
     return (
@@ -54,5 +54,5 @@ const BookmarkLoginComp = ({ folderState }: FolderProp) => {
     )
 }
 
-export default React.memo(BookmarkLoginComp);
+export default BookmarkLoginComp;
 // export default BookmarkLoginComp;

--- a/src/hooks/useMypage.ts
+++ b/src/hooks/useMypage.ts
@@ -1,30 +1,34 @@
 import { useQuery } from "@tanstack/react-query";
 import { mypageKeys } from "../apis/queries";
 import { apiPath } from "../shared/path";
-import { api_token } from "../shared/api";
+import api, { api_token } from "../shared/api";
 import { Feed } from "../pages/Mypage";
+import { useState } from "react";
+import { AxiosError } from "axios";
 
 const useMypage = () => {
 
-    // const typeFixedDispatch = stateDispatch as React.SetStateAction<Feed>;
-
-    const { refetch, isError, isSuccess, data } = useQuery({
+    const { refetch, isError, isSuccess, isLoading, data } = useQuery({
         queryKey: mypageKeys.GET_MYPAGE,
         queryFn: async () => {
+
             const res = await api_token.get(apiPath.mypage);
+            if (res.status === 401) {
+                throw new Error("비로그인");
+            }
+
             const result = res.data.mypages as Feed[];
             return result[0] as Feed;
         },
-        refetchOnMount: true,
-        refetchOnReconnect: true,
-        onSuccess(data) {
-        },
-        onError(err) {
+        onError(err: AxiosError) {
+            if (err.response?.status === 401) {
+                console.log(err);
+                return;
+            }
             throw err;
         }
     });
-
-    return { refetch, isError, isSuccess, data };
+    return { refetch, isError, isSuccess, isLoading, data };
 }
 
 export default useMypage;

--- a/src/pages/Bookmark.tsx
+++ b/src/pages/Bookmark.tsx
@@ -3,10 +3,6 @@ import styled from 'styled-components';
 import { Headers } from '../components/ui/element/headers/Headers';
 import { VFlex } from '../custom/ym/styleStore';
 import BookmarkList from '../components/bookmark/BookmarkList';
-import { useQuery } from '@tanstack/react-query';
-import { scrapKeys } from '../apis/queries';
-import { api_token } from '../shared/api';
-import { apiPath } from '../shared/path';
 import { FolderData, PayloadFolderList, PayloadShopList, ReceivedBookmarks, ScrapListEachData } from '../custom/ym/types';
 import useScrapData from '../hooks/useScrapData';
 import { BookmarkContext, BookmarkDispatches, bookmarkContext, bookmarkDispatchesContext } from '../custom/ym/contextValues';
@@ -26,7 +22,7 @@ const Bookmark = () => {
     const [scrapList, setScrapList] = useState<ScrapListEachData[]>();
     const [modal, setModal] = useState<boolean>(false);
 
-    const { scrapData, refetchScrapQuery, isSuccess, isError, isLoading } = useScrapData();
+    const { scrapData, isSuccess, isError, isLoading } = useScrapData();
     const { mutate } = useEditScrapData();
 
     const values: BookmarkContext = {
@@ -44,70 +40,45 @@ const Bookmark = () => {
         setScrapList
     };
 
-    const editBackClickHandler = () => {
-        setEditMode(false);
-    }
-
     const editFinishClickHandler = () => {
-        const newFolderList: PayloadFolderList[] = queryData?.folderList.map((folder) => {
+        const newFolderList: PayloadFolderList[]
+            = queryData?.folderList.map((folder) => {
 
-            const temp = scrapList?.map((element) => {
-                if (element.folderName === folder.folderName) {
-                    return { shopId: element.shopId } as PayloadShopList;
-                }
-                return null;
-            });
+                const temp = scrapList?.map((element) => {
+                    if (element.folderName === folder.folderName) {
+                        return { shopId: element.shopId } as PayloadShopList;
+                    }
+                    return null;
+                });
 
-            const result: PayloadFolderList = {
-                folderName: folder.folderName,
-                shopList: (temp as PayloadShopList[]).filter((element) => element !== null),
-            };
+                const result: PayloadFolderList = {
+                    folderName: folder.folderName,
+                    shopList: (temp as PayloadShopList[]).filter((element) => element !== null),
+                };
 
-            return result;
-        }) as PayloadFolderList[];
+                return result;
+            }) as PayloadFolderList[];
 
         const payload = {
             folderList: newFolderList,
         }
-
-        console.log('완료 누를시 완성되는 데이터 셋', newFolderList);
-
         mutate(payload);
 
         setEditMode(false);
     }
-
-    const editModeClickHandler = () => {
-        setEditMode(true);
-    }
-
-    const moveFolderClickhandler = () => {
-        setModal(true);
-    }
-
-    // if (isSuccess) {
-    //     setQueryData(scrapData);
-    //     setScrapList(scrapData?.scrapList);
-    // }
-
+    const editBackClickHandler = () => setEditMode(false);
+    const editModeClickHandler = () => setEditMode(true);
+    const moveFolderClickhandler = () => setModal(true);
 
     useEffect(() => {
-        // refetchScrapQuery();
-        // if (isLoading) {
-        // console.log('로딩중');
-        // }
         if (isSuccess) {
-            // console.log("통신성공")
             setQueryData(scrapData);
             setScrapList(scrapData?.scrapList);
-            console.log(scrapData);
-            console.log(scrapList);
         }
-    }, []);
+    }, [isSuccess, scrapData]);
 
-    if (isLoading) {
-        return <div>로딩중</div>;
-    };
+    if (isLoading) return <div>로딩중</div>;
+    if (isError) return <div>통신 에러</div>;
 
     return (
         <ScrapContext.Provider value={values}>
@@ -116,7 +87,7 @@ const Bookmark = () => {
                     ? <Modals.MoveScrapToOtherFolder
                         dispatch={setModal} />
                     : null}
-                {queryData
+                {isSuccess
                     ? <BookmarkContainer>
                         <VFlex>
                             {editMode

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -4,11 +4,6 @@ import { VFlex } from '../custom/ym/styleStore';
 import UserProfile from '../components/mypage/UserProfile';
 import MyFeeds from '../components/mypage/MyFeeds';
 import CustomerCenter from '../components/mypage/CustomerCenter';
-import { mypageData } from '../custom/ym/dummydata';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { mypageKeys } from '../apis/queries';
-import { api_token } from '../shared/api';
-import { apiPath } from '../shared/path';
 import NoLoginStatus from '../components/mypage/NoLoginStatus';
 import { ReceivedFeed } from '../custom/ym/types';
 import useMypage from '../hooks/useMypage';
@@ -43,19 +38,33 @@ const Mypage = () => {
     const [feedData, setFeedData] = useState<Feed | null>(null);
     const [isLogin, setIsLogin] = useState<boolean>(false);
 
-    const { refetch, data } = useMypage();
-
-
+    const { data, isSuccess, isError, isLoading, refetch } = useMypage();
 
     useEffect(() => {
-        if (data) {
-            setFeedData(data);
+        if (localStorage.getItem("access_token")) {
+            refetch();
+            setIsLogin(true);
+        } else {
+            setIsLogin(false);
         }
-        localStorage.getItem("access_token")
-            ? setIsLogin(true)
-            : setIsLogin(false);
         localStorage.setItem("nickname", feedData?.nickname as string);
-    }, [isLogin]);
+    }, []);
+
+    useEffect(() => {
+        if (isSuccess) {
+            setFeedData(data as Feed);
+            setIsLogin(true);
+            localStorage.setItem("nickname", data?.nickname as string);
+        }
+    }, [isSuccess, data]);
+
+    useEffect(() => {
+        isError && setIsLogin(false);
+    }, [isError]);
+
+    if (isLoading) return <div>로딩중</div>;
+
+
 
 
     return (

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -12,13 +12,7 @@ const api = axios.create({
   baseURL: `${process.env.REACT_APP_SERVER_URL}`,
 })
 
-export const api_token = axios.create({
-  baseURL: `${process.env.REACT_APP_SERVER_URL}`,
-  headers: {
-    "Authorization": localStorage.getItem("access_token"),
-    "authorization": localStorage.getItem("access_token"),
-  }
-})
+export const api_token = axios.create(axiosConfig);
 
 api.interceptors.request.use(
   // 요청을 보내기 전 수행되는 함수
@@ -34,10 +28,10 @@ api.interceptors.request.use(
   }
 )
 
-api.interceptors.response.use(
-  // 응답을 내보내기 전 수행되는 함수
-  function (response) {
-    return response;
+api_token.interceptors.request.use(
+  function (config) {
+    config.headers.Authorization = localStorage.getItem("access_token");
+    return config;
   },
 
   // 오류 응답을 내보내기 전 수행되는 함수


### PR DESCRIPTION
### **현상 및 수정 내용**



**1. 즐겨찾기 페이지 첫 렌더링 동작 제대로 안하는 현상:**

-.  문제 : 즐겨찾기 페이지를 들어갈 때 렌더링 된 결과 없이 백지 상태.

-.  원인 : 
1) 기존 코드에서 tanstack-query를 활용을 하려다가 Context API를 사용함에도 불구하고 Context를 사용하지 않고
각 컴포넌트별로 일부는 통신, 일부는 Context를 통해 컨트롤했음.
2) 예외적인 경우의 수를 만나고 나서 이상한 작동이 일어나기 시작하였고, 고치는 와중에 코드가 더 꼬임.

-. 해결 : 
1) 서버 response를 받고 나서 loading, error 등 분기처리 및 옵셔널체이닝에 대해 수정
2) 불필요한 코드 대거 삭제 및 불필요한 통신 삭제, context로 전역처리

-. 향후 과제 : 불필요한 요소 리렌더링 컨트롤



**2. 로그인 후, 새로고침을 하지 않으면 데이터가 제대로 보여지지 않는 현상**

-. 문제 : 로그인을 했음에도 불구하고 웹페이지에서 로그인한 유저의 정보를 가져오지 못하고, 새로고침 해야만 갖고 오는 현상.

-. 원인 :
1) 서버와의 통신을 할때, 미리 만들어둔 axios 객체 중, 토큰이 담긴 객체를 사용하여 통신을 실행.
2) Axios의 Interceptor를 활용하여 호출 당시에 저장된 토큰을 가져와야 했으나,
3) 초창기 코딩할때 이 부분을 건너뛰어서, 객체가 생성되는 그 순간의 토큰을 캡쳐하여 계속 서버와의 통신이 진행됨.
4) 따라서 비로그인 상태의 undefined로 할당된 토큰값이 계속하여 서버로 가서 제대로 값을 못가져 오는 것.

-. 해결 : interceptor에 request 직전에 로컬스토리지에 저장된 토큰값을 가져와서 갱신하도록 구성

**3. 비로그인 시, 화면이 로딩중에서 넘어가지 않는 현상**

-. 문제 : 비회원도 화면을 볼 수 있어야 하는데, 로딩중에서 넘어가지 않는 현상이 발생

-. 원인 :
1) 비회원일 시에도, 서버에서 데이터를 받아올 수 있지만 status에는 401을 담아서 보내주고 있음.
2) 에러로 분류되어서 계속해서 useQuery에서는 refetch를 진행하고 isLoading: true, isError: false인 상태가 유지됨.
3) 영원히 로딩중

-. 해결 :
1) onError의 콜백함수 내에서 조건문 생성
2) error 객체의 status가 401일때는 return;  할 것.(refetch를 진행하지 않을 것.)
3) 401이 발생할 경우에는 받아온 데이터는 그대로 사용하고 통상error로 분류하지 않는 것으로 해결
