### PR TITLE
FIX: 캐러셀 즐겨찾기 누를때 카드 되돌아가는 현상 수정 및 그 외

### DIFF
--- a/src/components/FeedNameCard.tsx
+++ b/src/components/FeedNameCard.tsx
@@ -10,7 +10,6 @@ const FeedNameCard = ({ nickname, createdAt }: { nickname?: string, createdAt?: 
     let date = '';
 
     if ((nickname === undefined) && (createdAt === undefined)) {
-        console.log(queryClient.getQueriesData(["GET_USER_FEED"]));
         data = queryClient.getQueriesData(["GET_USER_FEED"])[0][1] as TossedFeedData;
         date = moment(data?.createdAt).format("YYYY.MM.DD");
     }

--- a/src/components/bookmark/BookmarkList.tsx
+++ b/src/components/bookmark/BookmarkList.tsx
@@ -43,7 +43,7 @@ const BookmarkList = () => {
                     folderList?.map((element) => {
                         if (folder === element) {
                             return (
-                                <SwiperSlide style={{ paddingLeft: '0px' }}>
+                                <SwiperSlide style={{ width: 'fit-content' }}>
                                     <Categories.Active
                                         key={uuid()}
                                         name={element.folderName}
@@ -54,7 +54,7 @@ const BookmarkList = () => {
                             );
                         } else {
                             return (
-                                <SwiperSlide>
+                                <SwiperSlide style={{ width: 'fit-content' }}>
                                     <Categories.Inactive
                                         key={uuid()}
                                         name={element.folderName}

--- a/src/components/bookmark/EachFolder.tsx
+++ b/src/components/bookmark/EachFolder.tsx
@@ -23,7 +23,6 @@ const EachFolder = ({
     };
 
     const moveClickHandler = (direction: string, index: number) => {
-        console.log(index);
         if (direction === "down") {
             dispatch(prev => {
                 if (prev.length - 1 === index) {

--- a/src/components/feed/FeedContents.tsx
+++ b/src/components/feed/FeedContents.tsx
@@ -42,13 +42,10 @@ const FeedContents = ({ children }: Prop) => {
         refetch();
     }, []);
     useEffect(() => {
-        console.log(data);
     }, [isSuccess]);
+
     if (isLoading) return <div>로딩중</div>;
     if (isError) return <div>에러</div>
-
-    console.log("받은 파라미터:", children);
-    console.log("FeedContents 쿼리결과", data);
 
     return (
         <VFlex gap='12px' etc='padding:20px;'>

--- a/src/components/feed/PlaceBookMark.tsx
+++ b/src/components/feed/PlaceBookMark.tsx
@@ -18,8 +18,6 @@ const PlaceBookMark = ({ isScrap, shop }: { isScrap?: boolean, shop?: number }) 
     const { mutate } = useMutation({
         mutationKey: keys.PUT_TOGGLE_BOOKMARK,
         mutationFn: async (shop: number) => {
-            console.log("payload:", shop);
-            console.log('경로:', `/api/${shop}/scrap`);
             const res = await api_token.put(`/api/${shop}/scrap`);
             return res.data;
         },
@@ -27,7 +25,6 @@ const PlaceBookMark = ({ isScrap, shop }: { isScrap?: boolean, shop?: number }) 
             queryClient.invalidateQueries(["GET_USER_FEED"]);
             queryClient.invalidateQueries(queryKeys.GET_FEEDS);
             queryClient.invalidateQueries(queryKeys.GET_SHOP_DETAIL_FEED);
-            console.log("즐겨찾기 변경 성공");
         },
         onError: (error) => {
             throw error;

--- a/src/components/feed/PlacePicture.tsx
+++ b/src/components/feed/PlacePicture.tsx
@@ -8,9 +8,9 @@ const PlacePicture = ({
     imgUrl?: string,
     onClick: React.MouseEventHandler<HTMLDivElement>
 }) => {
-    // const { shopThumbnail } = mypageData.feeds[2] as EachFeed;
+
     const url: string = imgPath.shopThumbnailImg + imgUrl;
-    console.log(url);
+
     return (
         <PictureSize onClick={onClick}>
             <Picture src={url} alt="" />

--- a/src/components/map/CategoryButtonBar.tsx
+++ b/src/components/map/CategoryButtonBar.tsx
@@ -4,7 +4,6 @@ import { FILTER_LIST, LINE_MEDIUM, MEDIUM, STRONG_MEDIUM } from '../../custom/ym
 import { DispatchContext, StateContext } from '../../pages/Home';
 import { categoryTypes } from '../../custom/ym/types';
 import uuid from 'react-uuid';
-import { colorSet } from '../ui/styles/color';
 
 const CategoryButtonBar = () => {
     const { category } = useContext(StateContext);
@@ -18,9 +17,6 @@ const CategoryButtonBar = () => {
         } else {
             changeCategory(prev => buttonName);
         }
-
-        console.log(category);
-        // console.log(buttonName);
     }
 
     return (

--- a/src/components/map/MapHeader.tsx
+++ b/src/components/map/MapHeader.tsx
@@ -21,13 +21,13 @@ const MapHeader = () => {
                 <VFlex height="fit-content" etc='padding:20px 10px;'>
                     <AroundSpan>내 주변</AroundSpan>
                     <HFlex height='fit-content' gap='2px'>
-                        <RangeSpan>{range}m</RangeSpan>
+                        <RangeSpan>{range !== 0 ? `${range}m` : '다른 지역'}</RangeSpan>
                         <HeaderTextMedium>의 카페</HeaderTextMedium>
                     </HFlex>
                 </VFlex>
-                <Link 
+                <Link
                     to={`${path.search}`}
-                    state={{link: `${path.home}`}}
+                    state={{ link: `${path.home}` }}
                 >
                     <ButtonContainer>
                         <Image src={`${process.env.PUBLIC_URL}/icon/search_24.png`} alt="" />
@@ -38,7 +38,7 @@ const MapHeader = () => {
     )
 }
 
-export default MapHeader;
+export default React.memo(MapHeader);
 const AroundSpan = styled.span`
     font-size: ${BODY_5.fontSize};
     line-height: ${BODY_5.lineHeight};

--- a/src/components/map/MarkerMemo.tsx
+++ b/src/components/map/MarkerMemo.tsx
@@ -23,16 +23,15 @@ const MarkerMemo = ({ element, onClick }: MarkerProps) => {
         anchor: new navermaps.Point(0, 0),
     }
 
+    console.log('요소', element.shopName);
+
     return (
-        <div>
-            {/* <button></button> */}
-            <Marker
-                onClick={(e) => clickHandler(e, element.shopId)}
-                icon={element?.shopId === activeShop
-                    ? activeIcon
-                    : icon}
-                defaultPosition={new navermaps.LatLng(element.lat, element.lng)} />
-        </div>
+        <Marker
+            onClick={(e) => clickHandler(e, element.shopId)}
+            icon={element?.shopId === activeShop
+                ? activeIcon
+                : icon}
+            defaultPosition={new navermaps.LatLng(element.lat, element.lng)} />
     )
 }
 

--- a/src/components/map/ShopMaker.tsx
+++ b/src/components/map/ShopMaker.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { Marker, useNavermaps } from 'react-naver-maps';
+import { ShopData } from '../../custom/ym/variables';
+import { StateContext } from '../../pages/Home';
+
+const ShopMaker = ({ func, element
+}: {
+    func: (e: naver.maps.PointerEvent, shop: number) => void,
+    element: ShopData,
+}) => {
+    const navermaps = useNavermaps();
+
+    const icon = {
+        url: `${process.env.PUBLIC_URL}/markers/non_selected_shop.png`,
+        anchor: new navermaps.Point(0, 0),
+    }
+
+    const activeIcon = {
+        url: `${process.env.PUBLIC_URL}/markers/selected_shop.png`,
+        anchor: new navermaps.Point(0, 0),
+    }
+
+    return (
+        <StateContext.Consumer>
+            {value => <Marker
+                onClick={(e) => func(e, element.shopId)}
+                icon={element?.shopId === value.activeShop
+                    ? activeIcon
+                    : icon}
+                defaultPosition={new navermaps.LatLng(element.lat, element.lng)}
+            />}
+        </StateContext.Consumer>
+    )
+}
+
+export default ShopMaker;

--- a/src/components/mypage/FeedPictures.tsx
+++ b/src/components/mypage/FeedPictures.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom'
 import MyAllFeeds from './AllFeedsButton'
 import { ReceivedFeed } from '../../custom/ym/types'
 import { imgPath } from '../../shared/path'
+import uuid from 'react-uuid'
 
 type Props = {
     isAll: boolean,
@@ -22,8 +23,8 @@ const FeedPictures = ({ isAll, children }: Props) => {
         return (
             <HFlex gap='2px' height='fit-content' etc='flex-wrap: wrap;'>
                 {arr.map((element) => {
-                    return <Shot onClick={() => openFeedDetail(element.feadId as number)}>
-                        <FeedImg src={element?.feedPic} />
+                    return <Shot key={uuid()} onClick={() => openFeedDetail(element.feadId as number)}>
+                        <FeedImg key={uuid()} src={element?.feedPic} />
                     </Shot>;
                 })}
             </HFlex>
@@ -34,8 +35,8 @@ const FeedPictures = ({ isAll, children }: Props) => {
         <HFlex gap='2px' height='fit-content' etc='flex-wrap: wrap;'>
             {children?.map((element, index) => {
                 if (index < 9) {
-                    return <Shot onClick={() => openFeedDetail(element?.feadId as number)}>
-                        <FeedImg src={`${imgPath.feedImg}${element?.feedPic}`} />
+                    return <Shot key={uuid()} onClick={() => openFeedDetail(element?.feadId as number)}>
+                        <FeedImg key={uuid()} src={`${imgPath.feedImg}${element?.feedPic}`} />
                     </Shot>;
                 } else {
                     return null;

--- a/src/components/mypage/MyFeeds.tsx
+++ b/src/components/mypage/MyFeeds.tsx
@@ -11,7 +11,6 @@ const MyFeeds = () => {
             <MypageContext.Consumer>
                 {
                     value => {
-                        console.log(value);
                         return value?.props?.feedCount as number > 0
                             ? <>
                                 <FeedSet>{value?.props?.feedCount}</FeedSet>

--- a/src/components/mypage/UserProfile.tsx
+++ b/src/components/mypage/UserProfile.tsx
@@ -24,7 +24,6 @@ const UserProfile = () => {
             setProfilePic(data?.profilePic);
             setNickname(data?.nickname);
         }
-        console.log('유즈이펙트', data);
     }, [data]);
 
     return (

--- a/src/components/ui/element/cards/BookmarkCard.tsx
+++ b/src/components/ui/element/cards/BookmarkCard.tsx
@@ -55,22 +55,6 @@ const BookmarkCard = ({ data, idx }: BookmarkChildren) => {
         setScrapList(prev => {
             return prev.filter((element) => element !== data);
         });
-        // if (data.isScrap) {
-        //     mutate(data.shopId);
-        //     setScrapList(prev => {
-        //         const a = [...prev];
-        //         a[idx] = { ...data, isScrap: !data.isScrap };
-        //         return a;
-        //     })
-        // } else {
-        //     mutate(data.shopId);
-        //     setScrapList(prev => {
-        //         const a = [...prev];
-        //         a[idx] = { ...data, isScrap: !data.isScrap };
-        //         return a;
-        //     });
-        //     queryClient.invalidateQueries(mapQueryKeys.POST_SHOPS_IN_RANGE);
-        // }
     }
 
     return (

--- a/src/components/ui/modal/ModalContents.tsx
+++ b/src/components/ui/modal/ModalContents.tsx
@@ -153,7 +153,6 @@ const MoveToOtherFolder = ({ dispatch }: { dispatch: React.Dispatch<React.SetSta
             });
             return modifiedList;
         });
-        console.log('수정후', scrapList);
         const tempSetSelected = setSelected as React.Dispatch<React.SetStateAction<number[]>>;
         tempSetSelected(prev => []);
 

--- a/src/custom/ym/contextValues.ts
+++ b/src/custom/ym/contextValues.ts
@@ -4,47 +4,47 @@ import { ShopData } from "./variables"
 export interface States {
     range: number,
     category: categoryTypes | "",
-    list: (ShopData | null)[],
+    // list: (ShopData | null)[],
     userCoord: Coordinate,
     shopCoord: (Coordinate | null)[],
-    center: Coordinate,
-    isMoving: boolean,
-    isChanged: boolean,
+    // center: Coordinate,
+    // isMoving: boolean,
+    // isChanged: boolean,
     activeShop: number,
 }
 
 export const states: States = {
     range: 200,
     category: "",
-    list: [],
+    // list: [],
     userCoord: { lat: 37.5108407, lng: 127.0468975 },
     shopCoord: [],
-    center: { lat: 37.5108407, lng: 127.0468975 },
-    isMoving: false,
-    isChanged: false,
+    // center: { lat: 37.5108407, lng: 127.0468975 },
+    // isMoving: false,
+    // isChanged: false,
     activeShop: 0,
 }
 
 export interface Dispatches {
     setRange: React.Dispatch<React.SetStateAction<number>> | null,
     setCategory: React.Dispatch<React.SetStateAction<"" | categoryTypes>> | null,
-    setList: React.Dispatch<React.SetStateAction<(ShopData | null)[]>> | null,
+    // setList: React.Dispatch<React.SetStateAction<(ShopData | null)[]>> | null,
     setUserCoord: React.Dispatch<React.SetStateAction<Coordinate>> | null,
     setShopCoord: React.Dispatch<React.SetStateAction<Coordinate[]>> | null,
-    setCenter: React.Dispatch<React.SetStateAction<Coordinate>> | null,
-    setIsMoving: React.Dispatch<React.SetStateAction<boolean>> | null,
-    setIsChanged: React.Dispatch<React.SetStateAction<boolean>> | null,
+    // setCenter: React.Dispatch<React.SetStateAction<Coordinate>> | null,
+    // setIsMoving: React.Dispatch<React.SetStateAction<boolean>> | null,
+    // setIsChanged: React.Dispatch<React.SetStateAction<boolean>> | null,
     setActiveShop: React.Dispatch<React.SetStateAction<number>> | null
 }
 export const dispatches: Dispatches = {
     setRange: null,
     setCategory: null,
-    setList: null,
+    // setList: null,
     setUserCoord: null,
     setShopCoord: null,
-    setCenter: null,
-    setIsMoving: null,
-    setIsChanged: null,
+    // setCenter: null,
+    // setIsMoving: null,
+    // setIsChanged: null,
     setActiveShop: null,
 }
 export interface BookmarkContext {

--- a/src/custom/ym/shopCoordList.ts
+++ b/src/custom/ym/shopCoordList.ts
@@ -1,0 +1,14 @@
+import { Coordinate } from "./types";
+import { ShopData } from "./variables";
+
+const shopCoordList = (arr: ShopData[]) => {
+    const result: Coordinate[] = arr?.map((item) => {
+        return {
+            lng: item.lng,
+            lat: item.lat
+        }
+    })
+    return result;
+}
+
+export default shopCoordList;

--- a/src/hooks/makeArrayForCluster.ts
+++ b/src/hooks/makeArrayForCluster.ts
@@ -3,7 +3,6 @@ import { GuCoord, GuData, GuInformation, guList } from "../shared/guCoordInform"
 const makeArrayForCluster = (data: GuData[]) => {
 
     const result = data.map((element) => {
-        // console.log(element);
         const guCoordData: GuCoord = guList.filter((item) => item.guName === Object.keys(element)[0])[0];
         const newObj: GuInformation = {
             guName: Object.keys(element)[0],
@@ -11,15 +10,7 @@ const makeArrayForCluster = (data: GuData[]) => {
             lat: guCoordData.lat,
             lng: guCoordData.lng,
         }
-        // console.log(Object.keys(element));
-        // console.log(Object.values(element));
         return newObj;
-        // const guCoordData: GuCoord = guList.filter((item) => itemelement.guName)[0];
-        // console.log('guCoordData', guCoordData);
-        // console.log('element 쪼갠거',{...element});
-        // console.log('guCoordData.lat', guCoordData.lat)
-        // return { ...element, lat: guCoordData.lat, lng: guCoordData.lng } as GuInformation;
-        // return guCoordData;
     });
 
     return result;

--- a/src/hooks/useCreateFolder.ts
+++ b/src/hooks/useCreateFolder.ts
@@ -9,7 +9,6 @@ const useCreateFolder = () => {
         mutationKey: scrapKeys.POST_FOLDER,
         mutationFn: async (payload: object) => {
             const res = await api_token.post(apiPath.createScrapFolder, payload);
-            // console.log('생성 결과', res);
             return res.data;
         },
         onSuccess: () => {

--- a/src/hooks/useDeleteFolder.ts
+++ b/src/hooks/useDeleteFolder.ts
@@ -9,7 +9,7 @@ const useDeleteFolder = () => {
         mutationKey: scrapKeys.DELETE_FOLDER,
         mutationFn: async (folderNumber: number) => {
             const res = await api_token.delete(apiPath.deleteScrapFolder + `/${folderNumber}`);
-            console.log(res);
+            return res;
         },
         onSuccess: () => {
             queryClient.invalidateQueries(scrapKeys.GET_SCRAP);

--- a/src/hooks/useEditScrapData.ts
+++ b/src/hooks/useEditScrapData.ts
@@ -9,7 +9,7 @@ const useEditScrapData = () => {
         mutationKey: scrapKeys.POST_SCRAP_DB,
         mutationFn: async (payload: PayloadForModifyScrapData) => {
             const res = await api_token.post(apiPath.postScrapData, payload);
-            console.log(res.data);
+            return res;
         }
     });
 

--- a/src/hooks/useScrapToggle.ts
+++ b/src/hooks/useScrapToggle.ts
@@ -7,15 +7,12 @@ const useScrapToggle = () => {
     const { mutate, isSuccess, isLoading, isError } = useMutation({
         mutationKey: keys.PUT_TOGGLE_BOOKMARK,
         mutationFn: async (payload: number) => {
-            console.log("payload:", payload);
-            console.log('경로:', `/api/${payload}/scrap`);
             const res = await api_token.put(`/api/${payload}/scrap`);
             return res.data;
         },
         onSuccess: () => {
             queryClient.invalidateQueries(mapQueryKeys.POST_SHOPS_IN_RANGE);
             // queryClient.invalidateQueries(scrapKeys.GET_SCRAP);
-            console.log("즐겨찾기 변경 성공");
         },
         onError: (error) => {
             throw error;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,6 +9,9 @@ import useMapDataCall from '../hooks/useMapDataCall';
 import { dispatches, states } from '../custom/ym/contextValues';
 import CategoryButtonBar from '../components/map/CategoryButtonBar';
 import { useLocation } from 'react-router-dom';
+import { getUserLocation } from '../custom/jh/getUserLocation';
+import { getRealtimeLocation } from '../custom/jh/getUserLocation';
+import shopCoordList from '../custom/ym/shopCoordList';
 
 
 export interface EachData {
@@ -24,18 +27,44 @@ export interface EachData {
     lng: number
 }
 
+export interface CenterContextDefault {
+    center: Coordinate,
+    setCenter: React.Dispatch<React.SetStateAction<Coordinate>> | null
+}
+
+export interface ListContextDefault {
+    list: ShopData[] | null[],
+    setList: React.Dispatch<React.SetStateAction<ShopData[] | null[]>> | null
+}
+
+export interface Markers {
+    shopId: number,
+    lat: number,
+    lng: number,
+}
+
+const defaultCenter: CenterContextDefault = {
+    center: {
+        lat: 37.5108407,
+        lng: 127.0468975
+    },
+    setCenter: null,
+}
+
 export const StateContext = createContext(states);
 export const DispatchContext = createContext(dispatches);
+export const CenterContext = createContext(defaultCenter);
 
 const Home = () => {
 
     const [range, setRange] = useState(300);
     const [category, setCategory] = useState<categoryTypes | ''>('');
-    const [list, setList] = useState<(ShopData | null)[]>([]);
-    const [center, setCenter] = useState<Coordinate>({ lat: 37.5108407, lng: 127.0468975 });
-    const [isMoving, setIsMoving] = useState<boolean>(false);
-    const [isChanged, setIsChanged] = useState<boolean>(false);
+    const [list, setList] = useState<ShopData[] | null[]>([null]);
+    const [center, setCenter] = useState<Coordinate>(defaultCenter.center);
+    // const [isMoving, setIsMoving] = useState<boolean>(false);
+    // const [isChanged, setIsChanged] = useState<boolean>(false);
     const [activeShop, setActiveShop] = useState<number>(0);
+    const [markers, setMarkers] = useState<Markers[] | null[]>([]);
 
     // 실시간 유저 위치
     const [userCoord, setUserCoord] = useState<Coordinate>({ lat: 37.5108407, lng: 127.0468975 });
@@ -43,9 +72,11 @@ const Home = () => {
     // 샵 위치
     const [shopCoord, setShopCoord] = useState<Coordinate[]>([]);
 
-    const stateList = { userCoord, shopCoord, category, range, list, center, isMoving, isChanged, activeShop };
-    const dispatchList = { setRange, setCategory, setList, setUserCoord, setShopCoord, setCenter, setIsMoving, setIsChanged, setActiveShop };
-
+    // const stateList = { userCoord, shopCoord, category, range, list, center, isMoving, isChanged, activeShop };
+    // const dispatchList = { setRange, setCategory, setList, setUserCoord, setShopCoord, setCenter, setIsMoving, setIsChanged, setActiveShop };
+    const stateList = { userCoord, shopCoord, category, range, activeShop };
+    const dispatchList = { setRange, setCategory, setUserCoord, setShopCoord, setActiveShop };
+    const listArr = { list, setList }
     const { data, mutate, isSuccess, isError, isLoading, mutateAsync } = useMapDataCall();
 
     //검색 페이지에서 받는 위도 경도
@@ -57,16 +88,6 @@ const Home = () => {
         shopLat = Number(location.state.lat);
     }
 
-    const shopCoordList = (arr: ShopData[]) => {
-        const result: Coordinate[] = arr?.map((item) => {
-            return {
-                lng: item.lng,
-                lat: item.lat
-            }
-        })
-        return result;
-    }
-
     const userTextSelectLimit = `
     -ms-user-select: none; 
     -moz-user-select: -moz-none;
@@ -76,17 +97,42 @@ const Home = () => {
     overflow : hidden;
     `;
 
+    /* HTTPS로 전환할 경우, 현재 사용자 위치 가져올 것 */
+    // useEffect(() => {
+    //     getRealtimeLocation(setUserCoord);
+    //     setCenter(userCoord);
+    // }, []);
+
+    const convert = (data: ShopData[] | null[]) => {
+        if (data) {
+            return data?.map((element) => {
+                return {
+                    shopId: element?.shopId,
+                    lat: element?.lat,
+                    lng: element?.lng
+                } as Markers;
+            })
+        } else return [null];
+    }
+
     /* 비동기 처리를 위해 mutateAsync로 프로미스를 반환받고 state dispatch 진행 */
     useEffect(() => {
         const newPayload = { lng: center.lng, lat: center.lat, range: range };
         mutateAsync(newPayload)
-            .then((data) => {
-                setList(data);
-                setShopCoord(shopCoordList(data));
-                setIsMoving(false);
-                // console.log(list);
+            .then((data: ShopData[]) => {
+                const listPivot = list.map((element) => element?.shopId).sort() as number[];
+                const dataPivot = data?.map((element) => element?.shopId).sort() as number[];
+                const equal = (a: number[], b: number[]) => JSON.stringify(a) === JSON.stringify(b);
+                if (!equal(listPivot, dataPivot)) {
+                    setList(data);
+                    const searchResult = data?.filter(
+                        (item: ShopData) => item.category === category);
+                    setMarkers(convert(category ? searchResult : data));
+                    setShopCoord(shopCoordList(data));
+                }
             });
-    }, [range, center, isChanged]);
+    }, [range, center]);
+
 
     /* 카테고리 버튼에 대한 데이터 리렌더링 */
     useEffect(() => {
@@ -94,10 +140,12 @@ const Home = () => {
             setList(prev => {
                 const searchResult = data?.filter(
                     (item: ShopData) => item.category === category);
+                setMarkers(convert(searchResult));
                 return searchResult;
-            })
+            });
         } else {
             setList(data);
+            setMarkers(convert(data));
         }
     }, [category]);
 
@@ -106,12 +154,14 @@ const Home = () => {
         <VFlex etc={userTextSelectLimit}>
             <StateContext.Provider value={{ ...stateList }}>
                 <DispatchContext.Provider value={{ ...dispatchList }}>
-                    <VFlexCenter etc="min-width:390px; height:100%; flex:1;">
-                        <MapHeader />
-                        <MapModule />
-                    </VFlexCenter>
-                    <CategoryButtonBar />
-                    <CarouselBox />
+                    <CenterContext.Provider value={{ center, setCenter }}>
+                        <VFlexCenter etc="min-width:390px; height:100%; flex:1;">
+                            <MapHeader />
+                            <MapModule list={markers} setList={setMarkers} />
+                        </VFlexCenter>
+                        <CategoryButtonBar />
+                        <CarouselBox list={list} setList={setList} />
+                    </CenterContext.Provider>
                 </DispatchContext.Provider>
             </StateContext.Provider>
         </VFlex>


### PR DESCRIPTION
1. FIX :맵 화면의 캐러셀에서 즐겨찾기 추가 버튼을 누를때, 리렌더링되면서 캐러셀 첫번째 카드로 돌아가는 현상 수정
2. REFACTOR : 
-. 각종 확인용 콘솔로그 삭제
-. 불필요한 변수 및 스테이트 1차 삭제.
-. 로직변경: 맵 컨트롤 시 Center 관련하여, 화면이 이동하면서 계속 리렌더링되어 맵 중심이 흔들리는 현상 완전 제거
(기존 : NaverMap 컴포넌트의 프로퍼티를 이용해서 center와 zoom을 통제
개선 :요소 ref를 통해 객체를 직접 컨트롤)