### PR TITLE
FEAT: 마커클러스터 기능 추가

### DIFF
--- a/src/components/map/carousel/CarouselBox.tsx
+++ b/src/components/map/carousel/CarouselBox.tsx
@@ -65,13 +65,16 @@ const CarouselBox = ({ list, setList }: ListContextDefault) => {
     }, [list]);
 
     useEffect(() => {
-        const activeChange = setActiveShop as React.Dispatch<React.SetStateAction<number>>;
-        activeChange(list[now]?.shopId as number);
+        if (list) {
+            setActiveShop && setActiveShop(list[now] as ShopData ? list[now].shopId : 0);
+        }
     }, [now]);
 
     useEffect(() => {
-        const index = list?.findIndex((element) => element?.shopId === activeShop);
-        swiper?.slideTo(index);
+        if (list) {
+            const index = list?.findIndex((element) => element?.shopId === activeShop);
+            swiper?.slideTo(index);
+        }
     }, [activeShop])
 
     return (

--- a/src/custom/ym/variables.ts
+++ b/src/custom/ym/variables.ts
@@ -167,3 +167,6 @@ export const scrapImg = {
     checked: 'bookmark checked.png',
     notChecked: 'book mark white_28.png'
 }
+
+
+export const clusterHTML = '<div style="cursor:pointer;width:40px;height:40px;line-height:42px;font-size:10px;color:white;text-align:center;font-weight:bold;background-color:gray;border-radius:50%;">dd</div>'

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -34,8 +34,8 @@ export interface CenterContextDefault {
 }
 
 export interface ListContextDefault {
-    list: ShopData[] | null[],
-    setList: React.Dispatch<React.SetStateAction<ShopData[] | null[]>> | null
+    list: ShopData[] | null,
+    setList: React.Dispatch<React.SetStateAction<ShopData[] | null>> | null
 }
 
 export interface Markers {
@@ -64,7 +64,7 @@ const Home = () => {
 
     const [range, setRange] = useState(300);
     const [category, setCategory] = useState<categoryTypes | ''>('');
-    const [list, setList] = useState<ShopData[] | null[]>([null]);
+    const [list, setList] = useState<ShopData[] | null>(null);
     const [center, setCenter] = useState<Coordinate>(defaultCenter.center);
     // const [isMoving, setIsMoving] = useState<boolean>(false);
     // const [isChanged, setIsChanged] = useState<boolean>(false);
@@ -125,22 +125,36 @@ const Home = () => {
         }
     }, [])
 
+    useEffect(() => {
+        const listPivot = list?.map((element) => element?.shopId).sort() as number[];
+        const dataPivot = data?.map((element: ShopData) => element?.shopId).sort() as number[];
+        const equal = (a: number[], b: number[]) => JSON.stringify(a) === JSON.stringify(b);
+        if (!equal(listPivot, dataPivot)) {
+            setList(data);
+            const searchResult = data?.filter(
+                (item: ShopData) => item.category === category);
+            setMarkers(convert(category ? searchResult : data));
+            setShopCoord(shopCoordList(data));
+        }
+    }, [isSuccess]);
+
     /* 비동기 처리를 위해 mutateAsync로 프로미스를 반환받고 state dispatch 진행 */
     useEffect(() => {
         const newPayload = { lng: center.lng, lat: center.lat, range: range };
-        mutateAsync(newPayload)
-            .then((data: ShopData[]) => {
-                const listPivot = list?.map((element) => element?.shopId).sort() as number[];
-                const dataPivot = data?.map((element) => element?.shopId).sort() as number[];
-                const equal = (a: number[], b: number[]) => JSON.stringify(a) === JSON.stringify(b);
-                if (!equal(listPivot, dataPivot)) {
-                    setList(data);
-                    const searchResult = data?.filter(
-                        (item: ShopData) => item.category === category);
-                    setMarkers(convert(category ? searchResult : data));
-                    setShopCoord(shopCoordList(data));
-                }
-            });
+        // mutateAsync(newPayload)
+        //     .then((data: ShopData[]) => {
+        //         const listPivot = list?.map((element) => element?.shopId).sort() as number[];
+        //         const dataPivot = data?.map((element) => element?.shopId).sort() as number[];
+        //         const equal = (a: number[], b: number[]) => JSON.stringify(a) === JSON.stringify(b);
+        //         if (!equal(listPivot, dataPivot)) {
+        //             setList(data);
+        //             const searchResult = data?.filter(
+        //                 (item: ShopData) => item.category === category);
+        //             setMarkers(convert(category ? searchResult : data));
+        //             setShopCoord(shopCoordList(data));
+        //         }
+        //     });
+        mutate(newPayload);
     }, [range, center]);
 
 
@@ -159,7 +173,7 @@ const Home = () => {
         }
     }, [category]);
 
-    if (isLoading) return <Loading />;
+    // if (isLoading) return <Loading />;
 
     return (
         <VFlex etc={userTextSelectLimit}>


### PR DESCRIPTION
1. 렌더링 시 서버로부터 지역구별 개수 제공받아 저장
2. 맵의 zoom을 밀었을 경우에 샵마커를 제거하고 지역구별 클러스터를 가져오도록 구현
3. 클러스터를 클릭할 경우, 맵의 센터좌표가 해당 클러스터 좌표로 변경되고 줌을 확대