### PR TITLE
FIX: 맵에서 검색할 경우, 렌더링 시점 안맞는 부분 수정

### DIFF
--- a/src/components/map/MapModule.tsx
+++ b/src/components/map/MapModule.tsx
@@ -209,41 +209,26 @@ const MapModule = () => {
         return result
     }
 
-    const convert = (data: ShopData[] | null[] | null) => {
-        if (data) {
-            return data?.map((element) => {
-                return {
-                    shopId: element?.shopId,
-                    lat: element?.lat,
-                    lng: element?.lng
-                } as Markers;
-            })
-        } else return [null];
-    }
-
-
-
-
     useEffect(() => {
-        const newPayload = { lng: center.lng, lat: center.lat, range: 1000 };
-        localStorage.setItem("lng", String(center.lng));
-        localStorage.setItem("lat", String(center.lat));
-        mutate(newPayload);
+        if (location.state) {
+            const searchedShop = {
+                lng: Number(location.state.lng),
+                lat: Number(location.state.lat),
+                range: 1000,
+            };
+            setCenter && setCenter({ lat: searchedShop.lat, lng: searchedShop.lng });
+            mutate(searchedShop);
+        } else {
+            const newPayload = { lng: center.lng, lat: center.lat, range: 1000 };
+            localStorage.setItem("lng", String(center.lng));
+            localStorage.setItem("lat", String(center.lat));
+            mutate(newPayload);
+        }
     }, []);
 
     useEffect(() => {
         isSuccess && refreshListByRange(data);
     }, [isSuccess]);
-
-    useEffect(() => {
-        if (location.state) {
-            const searchedShop = {
-                shopLng: Number(location.state.lng),
-                shopLat: Number(location.state.lat)
-            };
-            setCenter && setCenter({ lat: searchedShop.shopLat, lng: searchedShop.shopLng });
-        }
-    }, [location.state]);
 
     useEffect(() => {
         refreshData();


### PR DESCRIPTION
1. 기존 : useEffect(() =>{}, [location.state]) 에서 처리.
2. 변경사항 : useEffect(() => {}, []), 첫 렌더링때 location.state의 값이 있을 경우에는 맵의 시작 위치가 그 지점을 향하도록 변경
3. 변경사유 : 새창에서 가져오기때문에 결국 의존성배열이 null인 useEffect에서 렌더링 시점을 결정지으므로, undefined된 좌표로 지정되어 map화면에 오류가 발생함
